### PR TITLE
multipart: Support parameters on file `Content-Type`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ var Busboy = require('busboy');
 http.createServer(function(req, res) {
   if (req.method === 'POST') {
     var busboy = new Busboy({ headers: req.headers });
-    busboy.on('file', function(fieldname, file, filename, encoding, mimetype) {
+    busboy.on('file', function(fieldname, file, filename, encoding, mimetype, fullmimetype) {
       var saveTo = path.join(os.tmpDir(), path.basename(fieldname));
       file.pipe(fs.createWriteStream(saveTo));
     });
@@ -116,7 +116,7 @@ var Busboy = require('busboy');
 http.createServer(function(req, res) {
   if (req.method === 'POST') {
     var busboy = new Busboy({ headers: req.headers });
-    busboy.on('file', function(fieldname, file, filename, encoding, mimetype) {
+    busboy.on('file', function(fieldname, file, filename, encoding, mimetype, fullmimetype) {
       console.log('File [' + fieldname + ']: filename: ' + filename);
       file.on('data', function(data) {
         console.log('File [' + fieldname + '] got ' + data.length + ' bytes');
@@ -172,8 +172,9 @@ _Busboy_ is a _Writable_ stream
 Busboy (special) events
 -----------------------
 
-* **file**(< _string_ >fieldname, < _ReadableStream_ >stream, < _string_ >filename, < _string_ >transferEncoding, < _string_ >mimeType) - Emitted for each new file form field found. `transferEncoding` contains the 'Content-Transfer-Encoding' value for the file stream. `mimeType` contains the 'Content-Type' value for the file stream.
+* **file**(< _string_ >fieldname, < _ReadableStream_ >stream, < _string_ >filename, < _string_ >transferEncoding, < _string_ >mimeType, < _string_ >fullMimeType) - Emitted for each new file form field found. `transferEncoding` contains the 'Content-Transfer-Encoding' value for the file stream. `mimeType` contains the 'Content-Type' value for the file stream.
     * Note: if you listen for this event, you should always handle the `stream` no matter if you care about the file contents or not (e.g. you can simply just do `stream.resume();` if you want to discard the contents), otherwise the 'finish' event will never fire on the Busboy instance. However, if you don't care about **any** incoming files, you can simply not listen for the 'file' event at all and any/all files will be automatically and safely discarded (these discarded files do still count towards `files` and `parts` limits).
+    * `mimeType` contains only the type and subtype - for example `application/octet-stream`. If access to the parameters are required, they are available as a string in the `fullMimeType` argument.
     * If a configured file size limit was reached, `stream` will both have a boolean property `truncated` (best checked at the end of the stream) and emit a 'limit' event to notify you when this happens.
 
 * **field**(< _string_ >fieldname, < _string_ >value, < _boolean_ >fieldnameTruncated, < _boolean_ >valueTruncated, < _string_ >transferEncoding, < _string_ >mimeType) - Emitted for each new non-file field found.

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -123,6 +123,7 @@ function Multipart(boy, cfg) {
 
     part.on('header', function(header) {
       var contype,
+          fullcontype,
           fieldname,
           parsed,
           charset,
@@ -132,6 +133,7 @@ function Multipart(boy, cfg) {
 
       if (header['content-type']) {
         parsed = parseParams(header['content-type'][0]);
+        fullcontype = header['content-type'][0];
         if (parsed[0]) {
           contype = parsed[0].toLowerCase();
           for (i = 0, len = parsed.length; i < len; ++i) {
@@ -210,7 +212,7 @@ function Multipart(boy, cfg) {
             cb();
           }
         };
-        boy.emit('file', fieldname, file, filename, encoding, contype);
+        boy.emit('file', fieldname, file, filename, encoding, contype, fullcontype);
 
         onData = function(data) {
           if ((nsize += data.length) > fileSizeLimit) {

--- a/test/test-types-multipart.js
+++ b/test/test-types-multipart.js
@@ -35,10 +35,31 @@ var tests = [
     expected: [
       ['field', 'file_name_0', 'super alpha file', false, false, '7bit', 'text/plain'],
       ['field', 'file_name_1', 'super beta file', false, false, '7bit', 'text/plain'],
-      ['file', 'upload_file_0', 1023, 0, '1k_a.dat', '7bit', 'application/octet-stream'],
-      ['file', 'upload_file_1', 1023, 0, '1k_b.dat', '7bit', 'application/octet-stream']
+      ['file', 'upload_file_0', 1023, 0, '1k_a.dat', '7bit', 'application/octet-stream', 'application/octet-stream'],
+      ['file', 'upload_file_1', 1023, 0, '1k_b.dat', '7bit', 'application/octet-stream', 'application/octet-stream']
     ],
     what: 'Fields and files'
+  },
+  { source: [
+    ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+      'Content-Disposition: form-data; name="from"',
+      '',
+      'A Sender',
+      '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+      'Content-Disposition: form-data; name="input-data"; filename="edi.dat"',
+      'Content-Type: multipart/encrypted;',
+      ' protocol="application/pgp-encrypted"; boundary="boundary2AW02w=="',
+      '',
+      'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+    ].join('\r\n')
+  ],
+    boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+    expected: [
+      ['field', 'from', 'A Sender', false, false, '7bit', 'text/plain'],
+      ['file', 'input-data', 1023, 0, 'edi.dat', '7bit', 'multipart/encrypted', 'multipart/encrypted; protocol="application/pgp-encrypted"; boundary="boundary2AW02w=="']
+    ],
+    what: 'Multipart File with full Content-Type'
   },
   { source: [
       ['------WebKitFormBoundaryTB2MiQ36fnSJlrhY',
@@ -91,7 +112,7 @@ var tests = [
     },
     expected: [
       ['field', 'file_name_0', 'super', false, true, '7bit', 'text/plain'],
-      ['file', 'upload_file_0', 13, 2, '1k_a.dat', '7bit', 'application/octet-stream']
+      ['file', 'upload_file_0', 13, 2, '1k_a.dat', '7bit', 'application/octet-stream', 'application/octet-stream']
     ],
     what: 'Fields and files (limits)'
   },
@@ -168,9 +189,9 @@ var tests = [
     ],
     boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
     expected: [
-      ['file', 'upload_file_0', 26, 0, '1k_a.dat', '7bit', 'application/octet-stream'],
-      ['file', 'upload_file_1', 26, 0, '1k_b.dat', '7bit', 'application/octet-stream'],
-      ['file', 'upload_file_2', 26, 0, '1k_c.dat', '7bit', 'application/octet-stream']
+      ['file', 'upload_file_0', 26, 0, '1k_a.dat', '7bit', 'application/octet-stream', 'application/octet-stream'],
+      ['file', 'upload_file_1', 26, 0, '1k_b.dat', '7bit', 'application/octet-stream', 'application/octet-stream'],
+      ['file', 'upload_file_2', 26, 0, '1k_c.dat', '7bit', 'application/octet-stream', 'application/octet-stream']
     ],
     what: 'Files with filenames containing paths'
   },
@@ -196,9 +217,9 @@ var tests = [
     boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
     preservePath: true,
     expected: [
-      ['file', 'upload_file_0', 26, 0, '/absolute/1k_a.dat', '7bit', 'application/octet-stream'],
-      ['file', 'upload_file_1', 26, 0, 'C:\\absolute\\1k_b.dat', '7bit', 'application/octet-stream'],
-      ['file', 'upload_file_2', 26, 0, 'relative/1k_c.dat', '7bit', 'application/octet-stream']
+      ['file', 'upload_file_0', 26, 0, '/absolute/1k_a.dat', '7bit', 'application/octet-stream', 'application/octet-stream'],
+      ['file', 'upload_file_1', 26, 0, 'C:\\absolute\\1k_b.dat', '7bit', 'application/octet-stream', 'application/octet-stream'],
+      ['file', 'upload_file_2', 26, 0, 'relative/1k_c.dat', '7bit', 'application/octet-stream', 'application/octet-stream']
     ],
     what: 'Paths to be preserved through the preservePath option'
   },
@@ -281,7 +302,7 @@ function next() {
     });
   }
   if (v.events === undefined || v.events.indexOf('file') > -1) {
-    busboy.on('file', function(fieldname, stream, filename, encoding, mimeType) {
+    busboy.on('file', function(fieldname, stream, filename, encoding, mimeType, fullMimeType) {
       var nb = 0,
           info = ['file',
                   fieldname,
@@ -289,7 +310,9 @@ function next() {
                   0,
                   filename,
                   encoding,
-                  mimeType];
+                  mimeType,
+                  fullMimeType
+                  ];
       results.push(info);
       stream.on('data', function(d) {
         nb += d.length;


### PR DESCRIPTION
This pull request adds support for passing the full contents of the `Content-Type` header for a file event, in order that a second instance of BusBoy can be used to read nested multipart content. This is common when used for parsing some EDI protocols - for example:

``` Content-Type: multipart/form-data; boundary="boundaryKU3VUg=="

--boundaryKU3VUg== Content-Disposition: form-data; name="from"

A Sender
--boundaryKU3VUg== Content-Disposition: form-data; name="input-data";
filename="edi.dat" Content-Type: multipart/encrypted;
protocol="application/pgp-encrypted"; boundary="boundary2AW02w=="

// More multipart content using the new boundary omitted here
```

So as not to change the existing behaviour, the full content type header is presented as an additional argument to the `file` event. This resulted in some changes to existing tests, since the optional final argument will be the same as the fifth if no parameters are present in the Content-Type header of the part.

We also update the README.md to reflect the new behaviour and note the difference between `mimeType` and `fullMimeType`.